### PR TITLE
bump datasets version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ click==8.1.8
 contourpy==1.3.2
 cryptography==44.0.3
 cycler==0.12.1
-datasets==3.6.0
+datasets==4.0.0
 debugpy==1.8.14
 dill==0.3.8
 distro==1.9.0


### PR DESCRIPTION
This relates to this change in datasets library:
<img width="981" height="551" alt="Screenshot 2025-07-24 at 11 55 51 AM" src="https://github.com/user-attachments/assets/10b6ae49-a38d-4e05-a7b0-4129eeb7da9b" />

This leads our schema generator to update the schema we publish to huggingface like this:
<img width="457" height="101" alt="Screenshot 2025-07-24 at 11 56 43 AM" src="https://github.com/user-attachments/assets/2a21e090-168e-4242-ac5f-a030b142f785" />


I am about to make a schema change in hf to support a PR from Jonathan to pipe through eval spec into results. I am testing leaderboard loading locally and seeing this error without the datasets library version change:
```
Using Hugging Face dataset for split 'validation': allenai/asta-bench-test-results/big_cheese
<p style='color: red; font-size: 20px; text-align: center;'>Error loading data for split 'validation': Feature type 'List' not found. Available feature types: ['Value', 'ClassLabel', 'Translation', 'TranslationVariableLanguages', 'LargeList', 'Sequence', 'Array2D', 'Array3D', 'Array4D', 'Array5D', 'Audio', 'Image', 'Video', 'Pdf']</p>
Using Hugging Face dataset for split 'test': allenai/asta-bench-test-results/big_cheese
<p style='color: red; font-size: 20px; text-align: center;'>Error loading data for split 'test': Feature type 'List' not found. Available feature types: ['Value', 'ClassLabel', 'Translation', 'TranslationVariableLanguages', 'LargeList', 'Sequence', 'Array2D', 'Array3D', 'Array4D', 'Array5D', 'Audio', 'Image', 'Video', 'Pdf']</p>
No valid data to plot after cleaning.
```

I don't see any negative impact locally from bumping the datasets version, so I think we should go ahead and change.