### PR TITLE
bump agenteval version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agent-eval==0.1.24
+agent-eval==0.1.28
 aiobotocore==2.22.0
 aiofiles==24.1.0
 aiohappyeyeballs==2.6.1


### PR DESCRIPTION
This picks up a change to warn rather than error when primary metric is mismatched with overall config in a result.

This updated agenteval version is already running in current hf leaderboard code.