### PR TITLE
bump agenteval

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agent-eval==0.1.28
+agent-eval==0.1.29
 aiobotocore==2.22.0
 aiofiles==24.1.0
 aiohappyeyeballs==2.6.1


### PR DESCRIPTION
picks up https://github.com/allenai/agent-eval/pull/49 (fix stderr metric extraction for core-bench; I guess it won't really matter until the lb uses the new metric names though)