### PR TITLE
Bump agent-eval version to pick up nulling out model usage info in some cases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agent-eval==0.1.31
+agent-eval==0.1.33
 aiobotocore==2.22.0
 aiofiles==24.1.0
 aiohappyeyeballs==2.6.1


### PR DESCRIPTION
To pick up the changes in https://github.com/allenai/astabench-issues/issues/330. This will also pick up https://github.com/allenai/agent-eval/pull/54.

Testing done:
I brought up a local version of the leaderboard.

Tracking down that example that changed from https://github.com/allenai/astabench-issues/issues/33:
<img width="1704" height="328" alt="image" src="https://github.com/user-attachments/assets/f45deef3-e5e9-42e6-9b1d-6cdde60d61ba" />

(on the left is the local version with these changes, on the right is the current deployed internal leaderboard)

