### PR TITLE
Make tooltips more dynamic

### DIFF
--- a/content.py
+++ b/content.py
@@ -636,7 +636,14 @@ span.wrap[tabindex="0"][role="button"][data-editable="false"] {
     right: 0;
     left: auto;
     transform: none;
-}   
+}
+.table-legend-item {  
+    display: flex; 
+    align-items: center; 
+    white-space: nowrap; 
+    margin-top: 8px; 
+    flex-wrap: wrap;
+}
 /* About Page CSS */
 #about-page-content-wrapper {
     margin-left: auto;

--- a/ui_components.py
+++ b/ui_components.py
@@ -334,13 +334,11 @@ def create_legend_markdown(which_table: str) -> str:
                 ⓘ
                 <span class="tooltip-card">{pareto_tooltip_content}</span>
             </span>
-            <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 16px; margin-top: 4px;">
-            <div style="display: flex; align-items: center; white-space: nowrap;">
-                <img src="{trophy_uri}" alt="On Frontier" style="width:16px; height:16px; margin-right: 4px; flex-shrink: 0;">
+            <div class="table-legend-item">
+                <img src="{trophy_uri}" alt="On Frontier" style="width:20px; height:20px; margin-right: 4px; flex-shrink: 0;">
                 <span>On frontier</span>
             </div>
         </div>
-    </div>
     
         <div> <!-- Container for the Openness section -->
             <b>Agent Openness</b>
@@ -352,7 +350,7 @@ def create_legend_markdown(which_table: str) -> str:
                     <div class="tooltip-items-container">{openness_tooltip_content}</div>
                 </span>
             </span>
-            <div style="display: flex; flex-wrap: wrap; align-items: center; margin-top: 8px;">{openness_html}</div>
+            <div class="table-legend-item">{openness_html}</div>
         </div>
     
         <div> <!-- Container for the Tooling section -->
@@ -365,7 +363,7 @@ def create_legend_markdown(which_table: str) -> str:
                     <div class="tooltip-items-container">{tooling_tooltip_content}</div>
                 </span>
             </span>
-            <div style="display: flex; flex-wrap: wrap; align-items: center; margin-top: 8px;">{tooling_html}</div>
+            <div class="table-legend-item">{tooling_html}</div>
         </div>
         
         <div><!-- Container for the Column Descriptions section -->


### PR DESCRIPTION
Work for https://github.com/allenai/astabench-issues/issues/385 and https://github.com/allenai/astabench-issues/issues/387

- Pinned pareto tooltip to the left
- Pinned column descriptions to the right
- Added some code to make them smarter on smoll screens
- Changed copy to the new copy


https://github.com/user-attachments/assets/02b94b90-eded-4af8-a282-ab2e96105c22

