### PR TITLE
Jason/filter submission files

### DIFF
--- a/submission.py
+++ b/submission.py
@@ -207,7 +207,7 @@ def add_new_eval(
                 fname = os.path.basename(member.name)
                 if not fname or fname.startswith("."): continue
                 # Keep only specific files as part of submissions.
-                if not fname.endswith(".eval") or fname == EVAL_CONFIG_FILENAME: continue
+                if not (fname.endswith(".eval") or fname == EVAL_CONFIG_FILENAME): continue
                 fobj = tar.extractfile(member)
                 if not fobj: continue
                 with open(os.path.join(extracted_dir, fname), "wb") as out:


### PR DESCRIPTION
Only keep .eval and eval_config.json

Used bug bash test file

Before file filtering you get all the files: https://huggingface.co/datasets/allenai/asta-bench-internal-submissions/commit/e5f284b27c3ea93eec23d5d181b95f2f4ec47130
After this PR: https://huggingface.co/datasets/allenai/asta-bench-internal-submissions/commit/39c7ade051ef342eb32bd88043b9bd2a195311b7

slack thread for context: https://allenai.slack.com/archives/C08QARYQGG4/p1755638671753089