### PR TITLE
Default value for cost divider line when no points have costs

### DIFF
--- a/leaderboard_transformer.py
+++ b/leaderboard_transformer.py
@@ -383,14 +383,18 @@ def _plot_scatter_plotly(
         valid_cost_data = data_plot[data_plot[x_col_to_use].notna()].copy()
         missing_cost_data = data_plot[data_plot[x_col_to_use].isna()].copy()
 
-        if not valid_cost_data.empty:
-            max_reported_cost = valid_cost_data[x_col_to_use].max()
-            # ---Calculate where to place the missing data and the divider line ---
-            divider_line_x = max_reported_cost + (max_reported_cost/10)
-            new_x_for_missing = max_reported_cost + (max_reported_cost/5)
+        # Hardcode for all missing costs for now, but ideally try to fallback
+        # to the max cost in the same figure in another split, if that one has data...
+        max_reported_cost = valid_cost_data[x_col_to_use].max() if not valid_cost_data.empty else 10
 
+        # ---Calculate where to place the missing data and the divider line ---
+        divider_line_x = max_reported_cost + (max_reported_cost/10)
+        new_x_for_missing = max_reported_cost + (max_reported_cost/5)
+        if not missing_cost_data.empty:
+            missing_cost_data[x_col_to_use] = new_x_for_missing
+
+        if not valid_cost_data.empty:
             if not missing_cost_data.empty:
-                missing_cost_data[x_col_to_use] = new_x_for_missing
                 # --- Combine the two groups back together ---
                 data_plot = pd.concat([valid_cost_data, missing_cost_data])
             else:
@@ -398,7 +402,6 @@ def _plot_scatter_plotly(
         else:
             # ---Handle the case where ALL costs are missing ---
             if not missing_cost_data.empty:
-                missing_cost_data[x_col_to_use] = 0
                 data_plot = missing_cost_data
             else:
                 data_plot = pd.DataFrame()


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/409.

For our validation set, for some figures, currently none of the points have cost values. Currently, this makes things look like this:

<img width="1167" height="768" alt="image" src="https://github.com/user-attachments/assets/3bcaf153-1ce5-48e3-bf5d-b3c7a06e403d" />

which looks a bit broken.

Currently, when at least one of the points has a cost value, we compute the divider line based on the maximum cost across the points with costs, and set the cost for points without costs to be a little bigger than it. When we don't have any costs, we don't include a divider line, and set the cost for points without costs to be 0.

This PR makes it so that when none of the points for a figure have cost values, we put the divider line at 10. (Note: I think maybe a little better would be to try falling back to the max cost for a corresponding figure from another split, but let's get this out for now.)

Testing done:
Tried it out locally:
<img width="1148" height="754" alt="image" src="https://github.com/user-attachments/assets/fd1da33f-3517-485c-8bb2-cc6e25442a81" />
