### PR TITLE
Bold overall stat columns on main leaderboards

### DIFF
--- a/content.py
+++ b/content.py
@@ -831,4 +831,10 @@ h3 .header-link-icon {
     margin-left: 6px;
     text-decoration: none;
 }
+
+/* Targets all "overall stats" columns in the main leaderboard for each category */
+#main-leaderboard td:nth-child(6) .prose,
+#main-leaderboard td:nth-child(7) .prose {
+    font-weight: 700 !important;
+}
 """

--- a/ui_components.py
+++ b/ui_components.py
@@ -611,6 +611,7 @@ def create_leaderboard_display(
             column_widths=final_column_widths,
             elem_classes=["wrap-header-df"],
             show_search="search",
+            elem_id="main-leaderboard"
         )
         legend_markdown = create_legend_markdown(category_name)
         gr.HTML(value=legend_markdown, elem_id="legend-markdown")


### PR DESCRIPTION
The overall stats on the main leaderboard for each category are bolded:
<img width="1839" height="683" alt="Screenshot 2025-08-25 at 11 02 25 AM" src="https://github.com/user-attachments/assets/1fd2396c-3575-42ce-8b0d-5ba94b1ff2a8" />
Stats on other leaderboards are not:
<img width="1834" height="676" alt="Screenshot 2025-08-25 at 11 02 33 AM" src="https://github.com/user-attachments/assets/70aee825-6fbe-4ad8-ae37-fe514df0dd89" />
