### PR TITLE
Jason/a few fixes for whatever.hf.space direct url

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # app.py
 import logging
+
 logging.basicConfig(level=logging.WARNING)
 
 import gradio as gr
@@ -193,7 +194,12 @@ final_css = css + f"""
 }}
 """
 # --- Gradio App Definition ---
-demo = gr.Blocks(theme=theme, css=final_css, head=scroll_script + redirect_script + tooltip_script)
+demo = gr.Blocks(
+    theme=theme,
+    css=final_css,
+    head=scroll_script + redirect_script + tooltip_script,
+    title="AstaBench Leaderboards",
+)
 with demo.route("Home", "/home"):
     build_main_page()
 

--- a/content.py
+++ b/content.py
@@ -240,6 +240,13 @@ css = """
     --color-text-light: var(--neutral-50); /* #FAF2E9 */
 }
 
+/* This makes space for the huggingface header bar which must shown on HF spaces. */
+/* FIXME Media queries don't seem to survive rendering. */
+/* @media (min-width: 768px) { ... } */
+gradio-app {
+    padding-top: 65px;
+}
+
 /* Global Styles */
 h2 {
     overflow: hidden;


### PR DESCRIPTION
page title and top padding since we are going with https://allenai-asta-bench-leaderboard.hf.space/ instead of the embedding iframe on huggingface.co

before
<img width="1276" height="289" alt="Screenshot 2025-08-25 at 11 04 51 AM" src="https://github.com/user-attachments/assets/dccd14a1-9e3a-46a8-948e-8e12b20d589d" />

after
<img width="1281" height="316" alt="Screenshot 2025-08-25 at 11 04 58 AM" src="https://github.com/user-attachments/assets/81bdd029-a896-44bf-9ac1-d2ce8fa55b82" />

the hf header bar doesn't appear on my local, but now there's space for it. tried media queries, but they didn't work, might be a gradio limitation; i found some bugs related to media queries on gradio github.

@MLatzke also tried nowrap on the nav elements, but it messed with the container width that I was worried it would actually create other problems in other elements down below since horizontal scroll seems to not work? at least on my mac. somebody else can mess with it, or put it in a paper cuts ticket for later
