### PR TITLE
Remove future diagram text

### DIFF
--- a/main_page.py
+++ b/main_page.py
@@ -17,9 +17,7 @@ CACHED_TAG_MAPS = {}
 
 def build_page():
     with gr.Column(elem_id="home-page-content-wrapper"):
-        with gr.Row(elem_id="intro-row"):
-            with gr.Column(scale=6):
-                gr.HTML(INTRO_PARAGRAPH, elem_id="intro-paragraph")
+        gr.HTML(INTRO_PARAGRAPH, elem_id="intro-paragraph")
 
     # --- Leaderboard Display Section ---
     gr.Markdown("---")


### PR DESCRIPTION
To tide us over since we had to remove the changes from https://github.com/allenai/asta-bench-leaderboard/pull/99 for now.

<img width="1763" height="764" alt="image" src="https://github.com/user-attachments/assets/7dfc6fec-f543-4f3a-910b-4f5b18a8fece" />

Left is the current leaderboard, right is my local.

My understanding is we just want to drop the text 'Future Diagram'.