### PR TITLE
Fix spacing for the home page

### DIFF
--- a/content.py
+++ b/content.py
@@ -823,7 +823,8 @@ html {
     }
 }
 #home-page-content-wrapper{
-    margin-top: 40px;
+    margin: 40px;
+    max-width: 60%;
 }
 #intro-paragraph {
     max-width: 90%;


### PR DESCRIPTION
Home page:

<img width="1662" height="693" alt="image" src="https://github.com/user-attachments/assets/bbb4f213-e53c-4af0-8402-fbe91919fb1c" />

Compare to literature understanding
<img width="1612" height="679" alt="image" src="https://github.com/user-attachments/assets/2dd09e0e-8992-43c6-9818-28c830aab68a" />

Home page in darkmode:
<img width="1620" height="731" alt="image" src="https://github.com/user-attachments/assets/bd2ef6f9-0142-4aa3-bf44-a3c817c0e172" />

