### PR TITLE
Disable share button on diagram

### DIFF
--- a/category_page_builder.py
+++ b/category_page_builder.py
@@ -35,6 +35,7 @@ def build_category_page(CATEGORY_NAME, PAGE_DESCRIPTION):
                         show_label=False,
                         show_download_button=False,
                         show_fullscreen_button=False,
+                        show_share_button=False,
                         interactive=False,
                         elem_id="diagram-image"
                     )

--- a/main_page.py
+++ b/main_page.py
@@ -27,6 +27,7 @@ def build_page():
                 interactive=False,
                 show_download_button=False,
                 show_fullscreen_button=False,
+                show_share_button=False,
                 elem_id="diagram-image"
             )
 


### PR DESCRIPTION
Fast follow to last PR

Locally this dumb little button doesn't show up - but it does once deployed - so get rid of it  😠 
<img width="1520" height="556" alt="Screenshot 2025-08-26 at 3 26 08 PM" src="https://github.com/user-attachments/assets/2ee40426-621f-4849-94e7-4be1103ec2e2" />
