### PR TITLE
Support env var overrides and fix DummyViewer hang

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,6 +38,8 @@ jobs:
     - name: Run unit tests
       run: |
         pytest tests/unit/ -v --tb=short
+      env:
+        PYTHONPATH: .
 
     - name: Run integration tests
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,6 +35,10 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
 
+    - name: Run unit tests
+      run: |
+        pytest tests/unit/ -v --tb=short
+
     - name: Run integration tests
       run: |
         pytest tests/integration/ -v --tb=short

--- a/config.py
+++ b/config.py
@@ -5,18 +5,24 @@ CONFIG_NAME = os.getenv("HF_CONFIG", "1.0.0-dev1") # This corresponds to 'config
 IS_INTERNAL = os.environ.get("IS_INTERNAL", "false").lower() == "true"
 
 # Put all contact info in the same dataset so there's only one place to search. This is private to Ai2.
-CONTACT_DATASET = f"allenai/asta-bench-internal-contact-info"
+CONTACT_DATASET = os.getenv("CONTACT_DATASET", "allenai/asta-bench-internal-contact-info")
 
-if IS_INTERNAL:
-    # datasets backing the internal leaderboard
-    SUBMISSION_DATASET = f"allenai/asta-bench-internal-submissions"
-    RESULTS_DATASET = f"allenai/asta-bench-internal-results"
-    LEADERBOARD_PATH = f"allenai/asta-bench-internal-leaderboard"
-else:
-    # datasets backing the public leaderboard
-    SUBMISSION_DATASET = f"allenai/asta-bench-submissions"
-    RESULTS_DATASET = f"allenai/asta-bench-results"
-    LEADERBOARD_PATH = f"allenai/asta-bench-leaderboard"
+# Allow env var overrides for dev/testing
+SUBMISSION_DATASET = os.getenv("SUBMISSION_DATASET")
+RESULTS_DATASET = os.getenv("RESULTS_DATASET")
+LEADERBOARD_PATH = os.getenv("LEADERBOARD_PATH")
+
+if not SUBMISSION_DATASET or not RESULTS_DATASET or not LEADERBOARD_PATH:
+    if IS_INTERNAL:
+        # datasets backing the internal leaderboard
+        SUBMISSION_DATASET = SUBMISSION_DATASET or "allenai/asta-bench-internal-submissions"
+        RESULTS_DATASET = RESULTS_DATASET or "allenai/asta-bench-internal-results"
+        LEADERBOARD_PATH = LEADERBOARD_PATH or "allenai/asta-bench-internal-leaderboard"
+    else:
+        # datasets backing the public leaderboard
+        SUBMISSION_DATASET = SUBMISSION_DATASET or "allenai/asta-bench-submissions"
+        RESULTS_DATASET = RESULTS_DATASET or "allenai/asta-bench-results"
+        LEADERBOARD_PATH = LEADERBOARD_PATH or "allenai/asta-bench-leaderboard"
 
 DATA_DIR = "/tmp/abl/data/" + CONFIG_NAME
 EXTRACTED_DATA_DIR = os.path.join(DATA_DIR, "extracted")

--- a/tests/unit/test_ui_components.py
+++ b/tests/unit/test_ui_components.py
@@ -1,0 +1,101 @@
+"""Unit tests for ui_components.py."""
+
+import pandas as pd
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ui_components import (
+    DummyViewer,
+    get_full_leaderboard_data,
+)
+
+
+class TestGetFullLeaderboardData:
+    """Tests for get_full_leaderboard_data function."""
+
+    @patch("ui_components.get_leaderboard_viewer_instance")
+    def test_returns_empty_for_dummy_viewer(self, mock_get_viewer):
+        """When DummyViewer is returned (error case), should return empty DataFrame."""
+        # DummyViewer is created when data loading fails
+        error_df = pd.DataFrame({"Message": ["Error loading data"]})
+        dummy_viewer = DummyViewer(error_df)
+        mock_get_viewer.return_value = (dummy_viewer, {"Overall": []})
+
+        df, tag_map = get_full_leaderboard_data("test")
+
+        assert df.empty
+        assert tag_map == {}
+
+    @patch("ui_components.get_leaderboard_viewer_instance")
+    def test_returns_empty_for_empty_leaderboard_viewer(self, mock_get_viewer):
+        """When LeaderboardViewer has no data, should return empty DataFrame."""
+        from agenteval.leaderboard.view import LeaderboardViewer
+
+        mock_viewer = MagicMock(spec=LeaderboardViewer)
+        mock_viewer._load.return_value = (pd.DataFrame(), {})
+        mock_get_viewer.return_value = (mock_viewer, {"Overall": []})
+
+        df, tag_map = get_full_leaderboard_data("test")
+
+        assert df.empty
+        assert tag_map == {}
+
+    @patch("ui_components.transform_raw_dataframe")
+    @patch("ui_components.create_pretty_tag_map")
+    @patch("ui_components.get_leaderboard_viewer_instance")
+    def test_transforms_valid_data(self, mock_get_viewer, mock_create_tag_map, mock_transform):
+        """When LeaderboardViewer has valid data, should transform and return it."""
+        from agenteval.leaderboard.view import LeaderboardViewer
+
+        # Create mock viewer with valid data
+        mock_viewer = MagicMock(spec=LeaderboardViewer)
+        raw_df = pd.DataFrame({
+            "agent_name": ["Test Agent"],
+            "score": [0.5],
+        })
+        mock_viewer._load.return_value = (raw_df, {})
+
+        raw_tag_map = {"overall": ["benchmark1"]}
+        mock_get_viewer.return_value = (mock_viewer, raw_tag_map)
+
+        # Mock the transformation functions
+        transformed_df = pd.DataFrame({
+            "Agent": ["Test Agent"],
+            "Score": ["50.0%"],
+        })
+        mock_transform.return_value = transformed_df
+
+        pretty_tag_map = {"Overall": ["Benchmark 1"]}
+        mock_create_tag_map.return_value = pretty_tag_map
+
+        df, tag_map = get_full_leaderboard_data("test")
+
+        assert not df.empty
+        assert "Agent" in df.columns
+        mock_transform.assert_called_once_with(raw_df)
+        mock_create_tag_map.assert_called_once()
+
+    @patch("ui_components.get_leaderboard_viewer_instance")
+    def test_returns_empty_for_unexpected_type(self, mock_get_viewer):
+        """When an unexpected type is returned, should return empty DataFrame."""
+        # This shouldn't happen in practice, but tests the fallback
+        mock_get_viewer.return_value = ("unexpected_string", {})
+
+        df, tag_map = get_full_leaderboard_data("test")
+
+        assert df.empty
+        assert tag_map == {}
+
+
+class TestDummyViewer:
+    """Tests for DummyViewer class."""
+
+    def test_load_returns_error_dataframe(self):
+        """DummyViewer._load() should return the error DataFrame it was initialized with."""
+        error_df = pd.DataFrame({"Message": ["Test error message"]})
+        dummy = DummyViewer(error_df)
+
+        result_df, result_map = dummy._load()
+
+        assert result_df.equals(error_df)
+        assert result_map == {}

--- a/ui_components.py
+++ b/ui_components.py
@@ -797,7 +797,11 @@ def get_full_leaderboard_data(split: str) -> tuple[pd.DataFrame, dict]:
     """
     viewer_or_data, raw_tag_map = get_leaderboard_viewer_instance(split)
 
-    if isinstance(viewer_or_data, (LeaderboardViewer, DummyViewer)):
+    if isinstance(viewer_or_data, DummyViewer):
+        # DummyViewer indicates an error occurred - return empty data
+        return pd.DataFrame(), {}
+
+    if isinstance(viewer_or_data, LeaderboardViewer):
         raw_df, _ = viewer_or_data._load()
         if raw_df.empty:
             return pd.DataFrame(), {}


### PR DESCRIPTION
## Summary
- Add env var overrides for dataset paths (`SUBMISSION_DATASET`, `RESULTS_DATASET`, `LEADERBOARD_PATH`) to enable local development with custom HF datasets
- Fix UI hang when `DummyViewer` is returned (error case) - now returns empty DataFrame immediately instead of trying to transform error data
- Add unit tests for `get_full_leaderboard_data` function
- Update CI to run unit tests alongside integration tests

## Test plan
- Unit tests pass locally
- Verified leaderboard UI works with dev datasets via Playwright

Related to: allenai/astabench-issues#483