### PR TITLE
Allow multiple submissions with the same agent name

### DIFF
--- a/leaderboard_transformer.py
+++ b/leaderboard_transformer.py
@@ -197,8 +197,49 @@ def transform_raw_dataframe(raw_df: pd.DataFrame) -> pd.DataFrame:
         if 'Score' in col or 'Cost' in col:
             transformed_df[col] = transformed_df[col].apply(_safe_round)
 
+    transformed_df = _disambiguate_duplicate_agents(transformed_df)
+
     logger.info("Raw DataFrame transformed: numbers rounded and columns renamed.")
     return transformed_df
+
+
+def _disambiguate_duplicate_agents(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Ensures no two rows are visually indistinguishable on the leaderboard.
+
+    Rows sharing the same agent name, submitter, and models used would otherwise
+    render identically. Such collisions are genuine re-runs (a submitter can only
+    submit once per 24h per split), so we keep the earliest occurrence's bare name
+    and append a sequential suffix to the rest (e.g. "RoboPhD (2)"), mirroring
+    agenteval's "index" duplicate handling.
+    """
+    dedup_cols = ["Agent", "Submitter", "Models Used"]
+    if df.empty or not all(col in df.columns for col in dedup_cols):
+        return df
+
+    df = df.reset_index(drop=True)
+    key = (
+        df["Agent"].astype(str)
+        + "\x1f"
+        + df["Submitter"].astype(str)
+        + "\x1f"
+        + df["Models Used"].apply(
+            lambda v: ",".join(map(str, v)) if isinstance(v, (list, tuple)) else str(v)
+        )
+    )
+
+    # Order so the earliest submission keeps the bare name (Date strings are
+    # "YYYY-MM-DD", which sort chronologically).
+    order = (
+        df.sort_values("Date", kind="stable").index
+        if "Date" in df.columns
+        else df.index
+    )
+    occurrence = key.loc[order].groupby(key.loc[order]).cumcount().reindex(df.index)
+    df["Agent"] = df["Agent"].astype(str) + occurrence.apply(
+        lambda n: f" ({n + 1})" if n > 0 else ""
+    )
+    return df
 
 
 class DataTransformer:

--- a/submission.py
+++ b/submission.py
@@ -27,7 +27,6 @@ from config import (
     CONFIG_NAME,
     CONTACT_DATASET,
     EXTRACTED_DATA_DIR,
-    RESULTS_DATASET,
     SUBMISSION_DATASET,
 )
 from content import (
@@ -128,15 +127,6 @@ def add_new_eval(
 
     logger.info(f"agent {agent_name}: Checking submission")
 
-    # Load current eval_results for submission checks
-    # This is a bit redundant if display part reloads it, but submission needs its own consistent view
-    current_eval_results_for_submission = try_load_dataset_submission(
-        RESULTS_DATASET,
-        CONFIG_NAME,
-        download_mode="force_redownload", # Or a less aggressive mode
-        verification_mode=VerificationMode.NO_CHECKS,
-    )
-
     submission_time = datetime.now(timezone.utc)
     if not username or username.strip() == "":
         username = profile.username # Default to HF username
@@ -190,18 +180,10 @@ def add_new_eval(
             gr.update(visible=False)                            # loading_modal
         )
 
-    logger.debug(f"agent {agent_name}: Duplicate submission check")
-    if val_or_test in current_eval_results_for_submission and len(current_eval_results_for_submission[val_or_test]) > 0:
-        existing_submissions = current_eval_results_for_submission[val_or_test].to_dict().get("submission", [])
-        for sub_item in existing_submissions:
-            if (sub_item.get("agent_name", "").lower() == agent_name.lower() and
-                    sub_item.get("username", "").lower() == username.lower()):
-                return (
-                    format_warning("This agent name by this user has already been submitted to this split."),  # error_message
-                    gr.update(visible=True),                            # error_modal
-                    gr.update(visible=False),                           # success_modal
-                    gr.update(visible=False)                            # loading_modal
-                )
+    # No agent-name uniqueness check: submissions get unique timestamped paths
+    # (so they can't overwrite each other) and the leaderboard disambiguates rows
+    # with identical agent name + submitter + models. Submitting the same agent
+    # name with different models is legitimate and should be allowed.
 
     safe_username = sanitize_path_component(username)
     safe_agent_name = sanitize_path_component(agent_name)


### PR DESCRIPTION
This changeset:
1. Disables the web form check that prevents a user from submitting more than one result with the same agent name
2. Adds a disambiguating numeral on the leaderboard if two rows have the same user/agent name/model name (which is not currently true of any rows on the public leaderboard, but can be seen if pointed at dev data). This mirrors what is built into the agent-eval `view` command designed for command-line access to the same data.

<img width="694" height="65" alt="Screenshot 2026-06-15 at 4 16 27 PM" src="https://github.com/user-attachments/assets/ffaf205d-e5fd-4fa7-8bbe-f7147bacb74c" />



Note that the web form check has never been exactly what we wanted, because we don't have access to model name at the point of web form submission (requires actually digging into the eval logs). In addition, external submitters keep (correctly) pointing out that we have enabled internal submitters to add many rows with the same agent name.

[Sample user comment:
> 2. Naming.
  As mentioned in an earlier email, the form wouldn't accept "RoboPhD" (which the form said was already taken by my earlier entries), so I submitted it as "RoboPhD 0.0.3." Would it make sense to just display it as "RoboPhD"?  There are multiple entries by Ai2 for "ReAct", as an example.]