### PR TITLE
Fix Pareto frontier strict-domination semantics

### DIFF
--- a/leaderboard_transformer.py
+++ b/leaderboard_transformer.py
@@ -87,11 +87,6 @@ ORDER_MAP = {
 }
 
 
-def _safe_round(value, digits=3):
-    """Rounds a number if it's a valid float/int, otherwise returns it as is."""
-    return round(value, digits) if isinstance(value, (float, int)) and pd.notna(value) else value
-
-
 def _pretty_column_name(raw_col: str) -> str:
     """
     Takes a raw column name from the DataFrame and returns a "pretty" version.
@@ -172,11 +167,12 @@ def create_pretty_tag_map(raw_tag_map: dict, name_map: dict) -> dict:
 
 def transform_raw_dataframe(raw_df: pd.DataFrame) -> pd.DataFrame:
     """
-    Transforms a raw leaderboard DataFrame into a presentation-ready format.
+    Renames raw leaderboard columns without changing metric precision.
 
-    This function performs two main actions:
-    1. Rounds all numeric metric values (columns containing 'score' or 'cost').
-    2. Renames all columns to a "pretty", human-readable format.
+    Score and cost values must remain at full precision here because downstream
+    calculations (including Pareto-frontier membership) consume this DataFrame.
+    Display-only rounding happens later in ``format_score_column``,
+    ``format_cost_column``, and the plot hover formatter.
     Args:
         raw_df (pd.DataFrame): The DataFrame with raw data and column names
                                like 'agent_name', 'overall/score', 'tag/code/cost'.
@@ -190,16 +186,12 @@ def transform_raw_dataframe(raw_df: pd.DataFrame) -> pd.DataFrame:
     # Create the mapping for pretty column names
     pretty_cols_map = {col: _pretty_column_name(col) for col in df.columns}
 
-    # Rename the columns and return the new DataFrame
+    # Rename columns, but retain the raw metric values for all calculations.
     transformed_df = df.rename(columns=pretty_cols_map)
-    # Apply safe rounding to all metric columns
-    for col in transformed_df.columns:
-        if 'Score' in col or 'Cost' in col:
-            transformed_df[col] = transformed_df[col].apply(_safe_round)
 
     transformed_df = _disambiguate_duplicate_agents(transformed_df)
 
-    logger.info("Raw DataFrame transformed: numbers rounded and columns renamed.")
+    logger.info("Raw DataFrame transformed: columns renamed; metric precision retained.")
     return transformed_df
 
 

--- a/leaderboard_transformer.py
+++ b/leaderboard_transformer.py
@@ -463,17 +463,21 @@ def _plot_scatter_plotly(
     if x_col_to_use and y_col_to_use:
         sorted_data = data_plot.sort_values(by=[x_col_to_use, y_col_to_use], ascending=[True, False])
         frontier_points = []
-        max_score_so_far = float('-inf')
+        # Best score reachable at a *strictly* lower cost than the current group.
+        best_below = float('-inf')
 
-        for _, row in sorted_data.iterrows():
-            score = row[y_col_to_use]
-            # Strict '>': points are visited in ascending-cost order, so a later
-            # point that only *ties* the running-max score is strictly dominated
-            # (same score, higher cost) and must be excluded from the frontier.
-            # Using '>=' here wrongly kept those dominated ties on the frontier.
-            if score > max_score_so_far:
-                frontier_points.append({'x': row[x_col_to_use], 'y': score})
-                max_score_so_far = score
+        # Group by cost so equal-cost points are compared as a set, not against
+        # each other. A point is on the frontier iff its score beats every
+        # strictly-cheaper point. Two points equal on *both* axes are mutually
+        # non-dominated, so both belong on the frontier; a point below its own
+        # cost group's max is dominated by a same-cost, higher-score point.
+        # (Testing score > running-max as we sweep individual points would wrongly
+        # drop one of two equal-cost / equal-score co-optimal points.)
+        for _, group in sorted_data.groupby(x_col_to_use, sort=True):
+            group_max = group[y_col_to_use].max()
+            if group_max > best_below:
+                frontier_points.append({'x': group[x_col_to_use].iloc[0], 'y': group_max})
+            best_below = max(best_below, group_max)
 
         if frontier_points:
             frontier_df = pd.DataFrame(frontier_points)
@@ -678,15 +682,22 @@ def get_pareto_df(data):
     frontier_data = frontier_data.sort_values(by=[x_col, y_col], ascending=[True, False])
 
     pareto_points = []
-    max_score_at_cost = -np.inf
+    # Best score reachable at a *strictly* lower cost than the current group.
+    best_below = -np.inf
 
-    for _, row in frontier_data.iterrows():
-        # Strict '>': rows are visited in ascending-cost order, so a later row
-        # that only ties the running-max score is strictly dominated (same
-        # score, higher cost) and must not be marked as a frontier/trophy row.
-        if row[y_col] > max_score_at_cost:
-            pareto_points.append(row)
-            max_score_at_cost = row[y_col]
+    # Group by cost so equal-cost rows are judged as a set. A row is on the
+    # frontier (gets a trophy) iff its score beats every strictly-cheaper row.
+    # Rows tied at their cost group's max score are equal on both axes, hence
+    # mutually non-dominated -> all get a trophy; rows below the group max are
+    # dominated by a same-cost, higher-score row and get none. Sweeping row by
+    # row with score > running-max would instead drop one of two equal-cost /
+    # equal-score co-optimal rows, which is why we compare against best_below.
+    for _, group in frontier_data.groupby(x_col, sort=True):
+        group_max = group[y_col].max()
+        if group_max > best_below:
+            for _, row in group[group[y_col] == group_max].iterrows():
+                pareto_points.append(row)
+        best_below = max(best_below, group_max)
 
     return pd.DataFrame(pareto_points)
 

--- a/leaderboard_transformer.py
+++ b/leaderboard_transformer.py
@@ -467,7 +467,11 @@ def _plot_scatter_plotly(
 
         for _, row in sorted_data.iterrows():
             score = row[y_col_to_use]
-            if score >= max_score_so_far:
+            # Strict '>': points are visited in ascending-cost order, so a later
+            # point that only *ties* the running-max score is strictly dominated
+            # (same score, higher cost) and must be excluded from the frontier.
+            # Using '>=' here wrongly kept those dominated ties on the frontier.
+            if score > max_score_so_far:
                 frontier_points.append({'x': row[x_col_to_use], 'y': score})
                 max_score_so_far = score
 
@@ -677,7 +681,10 @@ def get_pareto_df(data):
     max_score_at_cost = -np.inf
 
     for _, row in frontier_data.iterrows():
-        if row[y_col] >= max_score_at_cost:
+        # Strict '>': rows are visited in ascending-cost order, so a later row
+        # that only ties the running-max score is strictly dominated (same
+        # score, higher cost) and must not be marked as a frontier/trophy row.
+        if row[y_col] > max_score_at_cost:
             pareto_points.append(row)
             max_score_at_cost = row[y_col]
 

--- a/tests/integration/test_pareto_frontier.py
+++ b/tests/integration/test_pareto_frontier.py
@@ -59,3 +59,49 @@ def test_tied_score_at_higher_cost_is_not_drawn_on_frontier():
     frontier = next(trace for trace in figure.data if trace.name == "Efficiency Frontier")
     assert list(frontier.x) == [0.0368, 0.13]
     assert list(frontier.y) == [0.8533, 0.862]
+
+
+def _equal_cost_and_score_rows():
+    """Two entries equal on BOTH axes plus a same-cost lower-score entry.
+
+    ``co-opt-a`` and ``co-opt-b`` are identical in cost and score, so neither
+    dominates the other -> both belong on the frontier. ``same-cost-worse`` sits
+    at the same cost but a lower score, so it is dominated and must be dropped.
+    """
+    def _row(agent, cost, score):
+        return {
+            "Agent": agent,
+            "DS-1000 Score": score,
+            "DS-1000 Cost": cost,
+            "Openness": aliases.CANONICAL_OPENNESS_OPEN_SOURCE_CLOSED_WEIGHTS,
+            "Agent Tooling": aliases.CANONICAL_TOOL_USAGE_STANDARD,
+            "Models Used": ["m"],
+        }
+
+    return pd.DataFrame(
+        [
+            _row("co-opt-a", 0.0368, 0.8533),
+            _row("co-opt-b", 0.0368, 0.8533),
+            _row("same-cost-worse", 0.0368, 0.8000),
+            _row("higher-score", 0.13, 0.862),
+        ]
+    )
+
+
+def test_points_equal_on_both_axes_are_both_kept():
+    pareto = get_pareto_df(_equal_cost_and_score_rows())
+
+    assert sorted(pareto["Agent"].tolist()) == ["co-opt-a", "co-opt-b", "higher-score"]
+
+
+def test_equal_cost_lower_score_is_dropped_on_frontier_line():
+    figure = _plot_scatter_plotly(
+        _equal_cost_and_score_rows(),
+        x="DS-1000 Cost",
+        y="DS-1000 Score",
+        name="DS-1000",
+    )
+
+    frontier = next(trace for trace in figure.data if trace.name == "Efficiency Frontier")
+    assert list(frontier.x) == [0.0368, 0.13]
+    assert list(frontier.y) == [0.8533, 0.862]

--- a/tests/integration/test_pareto_frontier.py
+++ b/tests/integration/test_pareto_frontier.py
@@ -8,7 +8,11 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import aliases
-from leaderboard_transformer import _plot_scatter_plotly, get_pareto_df
+from leaderboard_transformer import (
+    _plot_scatter_plotly,
+    get_pareto_df,
+    transform_raw_dataframe,
+)
 
 
 def _tied_score_rows():
@@ -105,3 +109,32 @@ def test_equal_cost_lower_score_is_dropped_on_frontier_line():
     frontier = next(trace for trace in figure.data if trace.name == "Efficiency Frontier")
     assert list(frontier.x) == [0.0368, 0.13]
     assert list(frontier.y) == [0.8533, 0.862]
+
+
+def test_display_rounding_does_not_change_frontier_membership():
+    """Values that look tied at 3 decimals are compared at full precision."""
+    raw = pd.DataFrame(
+        [
+            {
+                "Agent": "raw-dominator",
+                "User/organization": "submitter-a",
+                "Models Used": ["model-a"],
+                "ds1000_test score": 0.85331,
+                "ds1000_test cost": 0.03681,
+            },
+            {
+                "Agent": "rounded-lookalike",
+                "User/organization": "submitter-b",
+                "Models Used": ["model-b"],
+                "ds1000_test score": 0.85330,
+                "ds1000_test cost": 0.03684,
+            },
+        ]
+    )
+
+    transformed = transform_raw_dataframe(raw)
+    pareto = get_pareto_df(transformed[["Agent", "DS-1000 Score", "DS-1000 Cost"]])
+
+    assert transformed["DS-1000 Score"].tolist() == [0.85331, 0.85330]
+    assert transformed["DS-1000 Cost"].tolist() == [0.03681, 0.03684]
+    assert pareto["Agent"].tolist() == ["raw-dominator"]

--- a/tests/integration/test_pareto_frontier.py
+++ b/tests/integration/test_pareto_frontier.py
@@ -1,0 +1,54 @@
+import pandas as pd
+
+import aliases
+from leaderboard_transformer import _plot_scatter_plotly, get_pareto_df
+
+
+def _tied_score_rows():
+    return pd.DataFrame(
+        [
+            {
+                "Agent": "cheaper-tie",
+                "DS-1000 Score": 0.8533,
+                "DS-1000 Cost": 0.0368,
+                "Openness": aliases.CANONICAL_OPENNESS_OPEN_SOURCE_CLOSED_WEIGHTS,
+                "Agent Tooling": aliases.CANONICAL_TOOL_USAGE_STANDARD,
+                "Models Used": ["model-a"],
+            },
+            {
+                "Agent": "dominated-tie",
+                "DS-1000 Score": 0.8533,
+                "DS-1000 Cost": 0.0519,
+                "Openness": aliases.CANONICAL_OPENNESS_OPEN_SOURCE_CLOSED_WEIGHTS,
+                "Agent Tooling": aliases.CANONICAL_TOOL_USAGE_STANDARD,
+                "Models Used": ["model-b"],
+            },
+            {
+                "Agent": "higher-score",
+                "DS-1000 Score": 0.862,
+                "DS-1000 Cost": 0.13,
+                "Openness": aliases.CANONICAL_OPENNESS_OPEN_SOURCE_CLOSED_WEIGHTS,
+                "Agent Tooling": aliases.CANONICAL_TOOL_USAGE_STANDARD,
+                "Models Used": ["model-c"],
+            },
+        ]
+    )
+
+
+def test_tied_score_at_higher_cost_is_not_marked_pareto():
+    pareto = get_pareto_df(_tied_score_rows())
+
+    assert pareto["Agent"].tolist() == ["cheaper-tie", "higher-score"]
+
+
+def test_tied_score_at_higher_cost_is_not_drawn_on_frontier():
+    figure = _plot_scatter_plotly(
+        _tied_score_rows(),
+        x="DS-1000 Cost",
+        y="DS-1000 Score",
+        name="DS-1000",
+    )
+
+    frontier = next(trace for trace in figure.data if trace.name == "Efficiency Frontier")
+    assert list(frontier.x) == [0.0368, 0.13]
+    assert list(frontier.y) == [0.8533, 0.862]

--- a/tests/integration/test_pareto_frontier.py
+++ b/tests/integration/test_pareto_frontier.py
@@ -1,4 +1,11 @@
+import sys
+from pathlib import Path
+
 import pandas as pd
+
+# The application uses a flat module layout rather than an installed package.
+# Ensure those modules are importable under CI's `pytest tests/integration/` invocation.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import aliases
 from leaderboard_transformer import _plot_scatter_plotly, get_pareto_df


### PR DESCRIPTION
## Problem

On the leaderboard, entries that are **strictly Pareto-dominated** can still land on the Efficiency Frontier and receive a 🏆 trophy. Reported for DS-1000 (Code & Execution): two RoboPhD submissions have the same full-precision score, `0.8533`, at costs `$0.0368` and `$0.0519`. The `$0.0519` entry is dominated by the `$0.0368` entry, yet both sit on the frontier and both get a trophy.

## Root causes and fix

Both frontier computations in `leaderboard_transformer.py` walked rows sorted by cost ascending / score descending and used `>=` against the running maximum:

- `_plot_scatter_plotly` (plot frontier trace)
- `get_pareto_df` (table trophy marker)

A later point that only ties the running maximum has the same score at higher cost and is strictly dominated. A simple `>` replacement is not sufficient, however: it would incorrectly discard the second of two entries equal on **both** cost and score, even though those entries are mutually non-dominated.

The corrected algorithm groups rows by full-precision cost and compares each group with the best score reachable at a **strictly lower** cost. It:

- keeps all entries tied at the maximum score for a cost group when that score beats all cheaper entries;
- drops lower-scoring entries at the same cost; and
- drops equal-scoring entries at a higher cost.

Metric rounding is presentation-only. `transform_raw_dataframe` preserves full-precision scores and costs for Pareto calculation; this PR intentionally leaves display formatting unchanged.

## Verification

- Regression tests cover both affected paths, equal-score/higher-cost domination, equal-cost/equal-score co-optima, same-cost/lower-score domination, and values that display identically at three decimals but differ at full precision (`5 passed`).
- The patched app was launched locally with the real public results (`HF_CONFIG=1.0.0`), then a headless Chrome session navigated the rendered Gradio UI to Code & Execution → DS-1000.

### Before (pre-fix UI)

![Before fix: both the dominated $0.05 row and the cheaper $0.04 row have trophies](https://github.com/allenai/asta-bench-leaderboard/releases/download/gas2own-attachments/pr122-before.png)

### After (this PR)

![After fix: the dominated $0.05 row has no trophy, while the cheaper $0.04 row retains it](https://github.com/allenai/asta-bench-leaderboard/releases/download/gas2own-attachments/pr122-after.png)

The rendered result is exact: the dominated `0.853 @ $0.05` RoboPhD row loses its trophy, while `0.853 @ $0.04` and the legitimately higher-scoring `0.862 @ $0.13` rows retain theirs.

Follow-up PR #124 subsequently added three-decimal cost display, full-precision score and cost values on hover, and confidence-interval UX without changing Pareto membership.

Suggested-by: @jbragg
