### PR TITLE
Restore gradio[oauth] deps so the Space starts (fix itsdangerous crash)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,11 @@ inspect_ai==0.3.203
 litellm==1.88.1
 
 # --- Gradio app + UI/data stack (kept at current pins to minimize churn) ---
-gradio==5.30.0
+# [oauth] pulls Authlib + itsdangerous, required because the Space enables
+# hf_oauth (README) and app.py builds an OAuth-protected /submit route. Without
+# the extra, uv drops those deps and the app crashes at startup with
+# "ModuleNotFoundError: No module named 'itsdangerous'".
+gradio[oauth]==5.30.0
 gradio_modal==0.0.4
 APScheduler==3.11.0
 datasets==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,17 @@ anyio==4.9.0
 apscheduler==3.11.0
 async-timeout==5.0.1
 attrs==25.3.0
+authlib==1.7.2
 beautifulsoup4==4.13.4
 black==25.1.0
 boto3==1.40.61
 botocore==1.40.61
 certifi==2025.4.26
+cffi==2.1.1
 charset-normalizer==3.4.2
 click==8.1.8
 contourpy==1.3.2
+cryptography==50.0.0
 cycler==0.12.1
 datasets==4.0.0
 debugpy==1.8.14
@@ -48,9 +51,11 @@ ijson==3.3.0
 importlib-metadata==8.7.0
 inspect-ai==0.3.203
 isort==6.0.1
+itsdangerous==2.2.0
 jinja2==3.1.6
 jiter==0.16.0
 jmespath==1.0.1
+joserfc==1.7.4
 jsonlines==4.0.0
 jsonpatch==1.33
 jsonpath-ng==1.8.0
@@ -85,6 +90,7 @@ plotly==6.0.1
 propcache==0.3.1
 psutil==7.0.0
 pyarrow==20.0.0
+pycparser==3.0
 pydantic==2.11.4
 pydantic-core==2.33.2
 pydub==0.25.1


### PR DESCRIPTION
## Problem

The private/internal leaderboard Space (`allenai/asta-bench-internal-leaderboard`, which mirrors `main`) crashes at startup:

```
ModuleNotFoundError: No module named 'itsdangerous'
ImportError: Cannot initialize OAuth ... Please run `pip install gradio[oauth]`
```

## Root cause

The `requirements.in` → `uv pip compile` migration pins **bare** `gradio==5.30.0`. That omits gradio's optional `[oauth]` extra, so the generated `requirements.txt` no longer contains `Authlib` or `itsdangerous`. The Space requires OAuth — `README.md` sets `hf_oauth: true` and `app.py` builds an OAuth-protected `/submit` route — so the app fails during `attach_oauth` at import time.

## Fix

- `requirements.in`: `gradio==5.30.0` → `gradio[oauth]==5.30.0` (with a comment explaining why).
- `requirements.txt`: regenerated with `uv pip compile`, **constrained to the existing lockfile** so the only changes are the newly-required packages:

```
+authlib==1.7.2
+cffi==2.1.1
+cryptography==50.0.0
+itsdangerous==2.2.0
+joserfc==1.7.4
+pycparser==3.0
```

No other pins changed; nothing was removed.

## Note

This is **not** the same as PR #124 (cost-precision/uncertainty UX). That branch predates the `requirements.in` migration and still carries the old hand-written lockfile that happened to list `itsdangerous`, so it is neither where this bug lives nor what feeds the internal Space. This targets `main` directly so the next push to the Space picks it up.

<!-- gas2own-origin: {"slack": {"channel": "C0ACNEFASS0", "thread_ts": "1785967495.608699"}} -->
